### PR TITLE
fix grammar fetch error messages

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -163,7 +163,10 @@ fn fetch_grammar(grammar: GrammarConfiguration) -> Result<()> {
             // Fetch the exact revision from the remote.
             // Supported by server-side git since v2.5.0 (July 2015),
             // enabled by default on major git hosts.
-            git(&grammar_dir, ["fetch", REMOTE_NAME, &revision])?;
+            git(
+                &grammar_dir,
+                ["fetch", "--depth", "1", REMOTE_NAME, &revision],
+            )?;
             git(&grammar_dir, ["checkout", &revision])?;
 
             println!(

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -127,18 +127,14 @@ where
             tx.send(job(grammar)).unwrap();
         });
     }
-    pool.join();
+
+    drop(tx);
 
     // TODO: print all failures instead of the first one found.
-    if let Some(failure) = rx.try_iter().find_map(|result| result.err()) {
-        Err(anyhow!(
-            "Failed to {} some grammar(s).\n{}",
-            action,
-            failure
-        ))
-    } else {
-        Ok(())
-    }
+    rx.iter()
+        .find(|result| result.is_err())
+        .map(|err| err.with_context(|| format!("Failed to {} some grammar(s)", action)))
+        .unwrap_or(Ok(()))
 }
 
 fn fetch_grammar(grammar: GrammarConfiguration) -> Result<()> {


### PR DESCRIPTION
I noticed the error messages still weren't showing the full context for why (e.g. missing directory), and I figured out why. This is what they look like now:

```
0: Failed to read directory "/home/dead10ck/.config/helix/runtime/grammars/sources/toml". Did you use 'hx --fetch-grammars'?
1: No such file or directory (os error 2
```

I also made the fetches shallow, so they are much quicker.