### PR TITLE
Add rainbows.scm for zig

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -124,4 +124,4 @@
 | wgsl | ✓ |  |  |  | `wgsl_analyzer` |
 | xit | ✓ |  |  |  |  |
 | yaml | ✓ |  | ✓ | ✓ | `yaml-language-server` |
-| zig | ✓ |  | ✓ |  | `zls` |
+| zig | ✓ |  | ✓ | ✓ | `zls` |

--- a/runtime/queries/zig/rainbows.scm
+++ b/runtime/queries/zig/rainbows.scm
@@ -29,6 +29,11 @@
   ; using []
   (SliceTypeStart)
   (SuffixOp)
+  
+  ; zig uses || for captures
+  (Payload         "|" @rainbow.bracket)
+  (PtrPayload      "|" @rainbow.bracket)
+  (PtrIndexPayload "|" @rainbow.bracket)
 ] @rainbow.scope
 
 [

--- a/runtime/queries/zig/rainbows.scm
+++ b/runtime/queries/zig/rainbows.scm
@@ -22,7 +22,6 @@
   ; using {}
   (Block)
   (BlockExpr)
-  (EscapeSequence)
   (FormatSequence)
   (InitList)
   

--- a/runtime/queries/zig/rainbows.scm
+++ b/runtime/queries/zig/rainbows.scm
@@ -1,0 +1,38 @@
+[
+  ; zig
+  (ArrayTypeStart)
+  ; using ()
+  (AsmExpr)
+  (AsmOutputItem)
+  (ByteAlign)
+  (CallConv)
+  (ContainerDeclType)
+  (ErrorSetDecl)
+  (FnCallArguments)
+  (ForPrefix)
+  (GroupedExpr)
+  (IfPrefix)
+  (ParamDeclList)
+  (SwitchExpr)
+  (WhileContinueExpr)
+  (WhilePrefix)
+  ; for align expressions
+  (PtrTypeStart)
+
+  ; using {}
+  (Block)
+  (BlockExpr)
+  (EscapeSequence)
+  (FormatSequence)
+  (InitList)
+  
+  ; using []
+  (SliceTypeStart)
+  (SuffixOp)
+] @rainbow.scope
+
+[
+  "(" ")"
+  "{" "}"
+  "[" "]"
+] @rainbow.bracket


### PR DESCRIPTION
I think this should be pretty much all of them.
I tested it in a few files and it seems rather good for now, however a couple of things to note:
for the explanation i feel like the `rainbow.include-children` wasn't all too well explained, as i figured that it would make sense to add string formatting options in zig as well (expressed like this: `print("Hello, {s}!", .{"World"});`) however i didn't managed to get it running.

There may be 2 different reasons as to why:
1. The query doesn't support it, however, i don't think this is the case as the tree-sitter grammar description seems to be rather clear about that it works: https://github.com/maxxnino/tree-sitter-zig/blob/433574f2a086a13cb30463f1f9c72a9be4f88a57/grammar.js#L839
2. Well i didn't figure out how it works.

I also think i have noticed, that there may be some issues with the indentation tree-sitter queries within Zig, but i will probably (if my suspicion turns out to be correct) in a seperate PR (to the original repo of course)